### PR TITLE
spinnaker/spinnaker#6218: Private Azure Storage is not supported

### DIFF
--- a/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
+++ b/front50-azure/src/main/java/com/netflix/spinnaker/front50/model/AzureStorageService.java
@@ -59,10 +59,12 @@ public class AzureStorageService implements StorageService {
         blobContainer = getBlobClient().getContainerReference(this.containerName);
         blobContainer.createIfNotExists();
         BlobContainerPermissions permissions = new BlobContainerPermissions();
-        permissions.setPublicAccess(BlobContainerPublicAccessType.CONTAINER);
+        // www.github.com/spinnaker/spinnaker/issues/6218 stop enforcing public access
+        permissions.setPublicAccess(BlobContainerPublicAccessType.CONTAINER.OFF);
         blobContainer.uploadPermissions(permissions);
       } catch (Exception e) {
-        // log exception
+        // log exception is missed
+        log.error(e.getMessage() + e.getCause() + e.getStackTrace());
         blobContainer = null;
       }
     }


### PR DESCRIPTION
Issue: spinnaker/spinnaker#6218
Issue Summary: Private Azure Storage is not supported by Spinnaker Front50
Cloud Provider(s): AZS
Environment: DEV and Prod
Feature Area:
Description: When we convert the Azure Storage container access to private from public access, Spinnker front50 service unable to retrieve the pipelines from Azure Storage.
Steps to Reproduce: Configure Azure Storage container access to private from public access and try to pull the pipelines of any application with in Spinnaker UI.
Additional Details:
Observed that Spinnaker front50 container is expecting Azure blob storage container with public access enabled always. Application code is trying to set the permission to public access and getting exception “com.microsoft.azure.storage.StorageException: Public access is not permitted on this storage account.” as we disabled public access.
Mitigation / Fix: Removed the code snippet which is enforcing public access of expecting Azure blob storage container. Able to build & run the spinnaker front50 in local environment and getting the pipeline details from storage as expected.
Code snippet(actual exception was not getting logged due this it took more time for us to understand the cause)